### PR TITLE
Fix missing go install action

### DIFF
--- a/.github/workflows/BuildAndTestGo.yml
+++ b/.github/workflows/BuildAndTestGo.yml
@@ -10,6 +10,11 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
+
       - name: Install kubectl
         run: |
           sudo apt-get update && sudo apt-get install -y apt-transport-https


### PR DESCRIPTION
PR Checklist:
- [x] Self-Review
- [x] Add/Update Comments
- [x] Add/Update Test
- [x] Add/Update Documentation

Added the missing go install github action command. I am wondering how this could be passed ci/cd before 🤷‍♂️